### PR TITLE
Change info text on login screen

### DIFF
--- a/frontend/src/use-cases/admin/screens/gamma-login/Gamma.screen.jsx
+++ b/frontend/src/use-cases/admin/screens/gamma-login/Gamma.screen.jsx
@@ -7,7 +7,7 @@ export const Gamma = props => (
     <GammaLoginContainer>
         <InfoCard>
             <DigitText.Text
-                text="Inloggning, endast för styrIT!"/>
+                text="Inloggning, endast för styrIT & MötespresidIT!"/>
         </InfoCard>
         {
             props.errorMsg !== "" && (


### PR DESCRIPTION
The text on the screen implies that only styrIT are able to login but MötespresidIT are also able to do so